### PR TITLE
feat: add manual venue alias fetch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,26 @@
 - Prefer incremental, easy-to-review changes.
 - Keep user-facing copy branded as `Zotero Extra`.
 
+## Planning & PR workflow
+
+- Default: keep plans in PR text, not repo files.
+- Put implementation plans, deferred work, and follow-up ideas in the PR description or PR comments.
+- Do not add `PLAN.md`, `TODO.md`, `ROADMAP.md`, scratch notes, or similar planning files for normal feature work.
+- Discover scope first, then choose the smallest coherent PR cut.
+- Split work explicitly into:
+  - Current PR: required to deliver the change cleanly now
+  - Later PRs: useful but not required, dependent, risky, or too large for the current diff
+- Record that split in the PR body under short sections such as `## Plan`, `## Deferred` / `## Follow-ups`, and `## Out of scope`.
+- Update PR text as understanding changes; do not leave stale plans behind.
+- Avoid repo pollution:
+  - no standalone planning files for one-off work
+  - no agent scratch files, dated notes, or temporary checklists
+  - no orphaned TODOs in code for work that belongs in a later PR; put that context in the PR instead
+- Create a persistent repo doc only when the note is durable across multiple PRs, useful to future implementers/reviewers, and substantive enough to live with the codebase.
+- Good candidates for repo docs: architecture decisions, data or `extra`-field schema/contracts, migration behavior, and user-visible behavior that future work must follow.
+- Not good candidates for repo docs: phase plans, feature task lists, session notes, and single-PR implementation checklists.
+- Rule of thumb: if the note is mainly about what to do next for this PR series, keep it in the PR; if it explains how the system should work over time, make it a repo doc.
+
 ## Agent note
 
 - For development workflow and Zotero API reference, agents should refer to the `zotero-plugin-template` skill.

--- a/addon/locale/en-US/addon.ftl
+++ b/addon/locale/en-US/addon.ftl
@@ -13,3 +13,12 @@ prefs-table-title = Title
 prefs-table-detail = Detail
 tabpanel-lib-tab-label = Lib Tab
 tabpanel-reader-tab-label = Reader Tab
+venue-alias-menuitem =
+    .label = Zotero Extra: Fetch Venue Alias
+venue-alias-no-items = No items selected
+venue-alias-no-update = No venue aliases were updated
+venue-alias-updated =
+    { $count ->
+        [one] Updated { $count } venue alias
+       *[other] Updated { $count } venue aliases
+    }

--- a/addon/locale/zh-CN/addon.ftl
+++ b/addon/locale/zh-CN/addon.ftl
@@ -13,3 +13,12 @@ prefs-table-title = 标题
 prefs-table-detail = 详情
 tabpanel-lib-tab-label = 库标签
 tabpanel-reader-tab-label = 阅读器标签
+venue-alias-menuitem =
+    .label = Zotero Extra: 获取期刊/会议别名
+venue-alias-no-items = 未选择条目
+venue-alias-no-update = 没有更新任何期刊/会议别名
+venue-alias-updated =
+    { $count ->
+        [one] 已更新 { $count } 个期刊/会议别名
+       *[other] 已更新 { $count } 个期刊/会议别名
+    }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -5,6 +5,7 @@ import {
   PromptExampleFactory,
   UIExampleFactory,
 } from "./modules/examples";
+import { VenueAliasFactory } from "./modules/venueAlias";
 import { getString, initLocale } from "./utils/locale";
 import { registerPrefsScripts } from "./modules/preferenceScript";
 import { createZToolkit } from "./utils/ztoolkit";
@@ -27,6 +28,8 @@ async function onStartup() {
   UIExampleFactory.registerRightClickMenuItem();
 
   UIExampleFactory.registerRightClickMenuPopup();
+
+  VenueAliasFactory.registerItemMenu();
 
   UIExampleFactory.registerWindowMenuWithSeparator();
 
@@ -164,6 +167,9 @@ function onShortcuts(type: string) {
 
 function onDialogEvents(type: string) {
   switch (type) {
+    case "fetchVenueAlias":
+      void VenueAliasFactory.fetchSelectedItems();
+      break;
     case "dialogExample":
       HelperExampleFactory.dialogExample();
       break;

--- a/src/modules/venueAlias.ts
+++ b/src/modules/venueAlias.ts
@@ -1,0 +1,137 @@
+import { getString, getLocaleID } from "../utils/locale";
+import { ExtraFieldTool } from "zotero-plugin-toolkit";
+
+const CROSSREF_API_URL = "https://api.crossref.org/works/";
+const VENUE_ALIAS_KEY = "Venue Alias";
+const extraFieldTool = new ExtraFieldTool();
+
+interface CrossrefWorkMessage {
+  "short-container-title"?: unknown;
+}
+
+interface CrossrefWorkResponse {
+  message?: CrossrefWorkMessage;
+}
+
+async function fetchCrossrefVenueAlias(
+  doi: string,
+): Promise<string | undefined> {
+  const response = await Zotero.HTTP.request(
+    "GET",
+    `${CROSSREF_API_URL}${encodeURIComponent(doi)}`,
+  );
+  const payload = JSON.parse(
+    response.responseText ?? "{}",
+  ) as CrossrefWorkResponse;
+  return extractVenueAliasFromCrossref(payload);
+}
+
+export function extractVenueAliasFromCrossref(
+  payload: CrossrefWorkResponse,
+): string | undefined {
+  const shortContainerTitle = payload.message?.["short-container-title"];
+  if (!Array.isArray(shortContainerTitle)) {
+    return undefined;
+  }
+
+  return shortContainerTitle
+    .find(
+      (value): value is string => typeof value === "string" && !!value.trim(),
+    )
+    ?.trim();
+}
+
+export function normalizeVenueAlias(alias: string): string | undefined {
+  const normalizedAlias = alias.replace(/\r?\n+/g, " ").trim();
+  return normalizedAlias || undefined;
+}
+
+async function updateVenueAliasForItem(item: Zotero.Item): Promise<boolean> {
+  const doi = item.getField("DOI").trim();
+  if (!doi) {
+    return false;
+  }
+
+  const nextAlias = await fetchCrossrefVenueAlias(doi);
+  if (!nextAlias) {
+    return false;
+  }
+
+  const normalizedAlias = normalizeVenueAlias(nextAlias);
+  if (!normalizedAlias) {
+    return false;
+  }
+
+  const currentAlias = extraFieldTool.getExtraField(item, VENUE_ALIAS_KEY);
+  if (currentAlias === normalizedAlias) {
+    return false;
+  }
+
+  await extraFieldTool.setExtraField(item, VENUE_ALIAS_KEY, normalizedAlias, {
+    append: false,
+  });
+  return true;
+}
+
+function getSelectedRegularItems(): Zotero.Item[] {
+  return ztoolkit
+    .getGlobal("ZoteroPane")
+    .getSelectedItems()
+    .filter((item): item is Zotero.Item => item.isRegularItem());
+}
+
+function showResultWindow(text: string, type: "default" | "success" | "fail") {
+  new ztoolkit.ProgressWindow(addon.data.config.addonName, {
+    closeOnClick: true,
+    closeTime: 5000,
+  })
+    .createLine({ text, type })
+    .show();
+}
+
+export class VenueAliasFactory {
+  static registerItemMenu() {
+    Zotero.MenuManager.registerMenu({
+      pluginID: addon.data.config.addonID,
+      menuID: "fetch-venue-alias",
+      target: "main/library/item",
+      menus: [
+        {
+          menuType: "menuitem",
+          l10nID: getLocaleID("venue-alias-menuitem"),
+          onCommand: () => addon.hooks.onDialogEvents("fetchVenueAlias"),
+        },
+      ],
+    });
+  }
+
+  static async fetchSelectedItems() {
+    const items = getSelectedRegularItems();
+    if (!items.length) {
+      showResultWindow(getString("venue-alias-no-items"), "fail");
+      return;
+    }
+
+    let updated = 0;
+
+    for (const item of items) {
+      try {
+        if (await updateVenueAliasForItem(item)) {
+          updated += 1;
+        }
+      } catch (error) {
+        ztoolkit.log("Failed to fetch venue alias", item.id, error);
+      }
+    }
+
+    if (updated > 0) {
+      showResultWindow(
+        getString("venue-alias-updated", { args: { count: updated } }),
+        "success",
+      );
+      return;
+    }
+
+    showResultWindow(getString("venue-alias-no-update"), "default");
+  }
+}

--- a/test/venueAlias.test.ts
+++ b/test/venueAlias.test.ts
@@ -1,0 +1,38 @@
+/// <reference types="mocha" />
+
+import { assert } from "chai";
+import {
+  extractVenueAliasFromCrossref,
+  normalizeVenueAlias,
+} from "../src/modules/venueAlias";
+
+describe("venue alias", function () {
+  it("extracts first non-empty short container title", function () {
+    const alias = extractVenueAliasFromCrossref({
+      message: {
+        "short-container-title": ["", "NeurIPS"],
+      },
+    });
+
+    assert.equal(alias, "NeurIPS");
+  });
+
+  it("returns undefined when short container title is absent", function () {
+    const alias = extractVenueAliasFromCrossref({
+      message: {},
+    });
+
+    assert.isUndefined(alias);
+  });
+
+  it("normalizes multiline aliases to one line", function () {
+    assert.equal(
+      normalizeVenueAlias("NeurIPS\nProceedings"),
+      "NeurIPS Proceedings",
+    );
+  });
+
+  it("returns undefined for blank normalized aliases", function () {
+    assert.isUndefined(normalizeVenueAlias("  \n  "));
+  });
+});

--- a/typings/i10n.d.ts
+++ b/typings/i10n.d.ts
@@ -23,4 +23,8 @@ export type FluentMessageId =
   | 'startup-begin'
   | 'startup-finish'
   | 'tabpanel-lib-tab-label'
-  | 'tabpanel-reader-tab-label';
+  | 'tabpanel-reader-tab-label'
+  | 'venue-alias-menuitem'
+  | 'venue-alias-no-items'
+  | 'venue-alias-no-update'
+  | 'venue-alias-updated';


### PR DESCRIPTION
## Summary
- add a manual item context-menu action to fetch `Venue Alias` from Crossref DOI metadata and store it in the item's `extra` field
- use `ExtraFieldTool` from `zotero-plugin-toolkit` for `extra` field reads/writes instead of manual parsing
- add locale strings, tests for Crossref alias extraction/normalization, and update agent guidance for PR-first planning workflow and ExtraFieldTool usage

## Plan
### Current PR
- ship the manual Crossref-based venue alias MVP
- store exactly one line in `extra`: `Venue Alias: <alias>`
- validate with build, lint, and test coverage
- document the repo workflow preference to keep plans and follow-up breakdowns in PR text rather than repo planning files

## Deferred
### Later PRs
1. UX polish
   - distinguish no DOI / no alias found / already up to date / request failure in user feedback
   - improve multi-selection result reporting
2. Optional source expansion
   - keep Crossref primary
   - add Semantic Scholar only as a fallback if Crossref proves insufficient for CS/AI conference aliases
3. Optional batch workflow
   - add selected-items refresh/fill-missing flows if the manual single action proves useful

## Out of scope
- namespace for `Venue Alias`
- canonical venue field
- source/timestamp/version metadata in `extra`
- background auto-fetch on import or selection
- generic enrichment framework

## Validation
- `npm run build`
- `npm run lint:check`
- `npm test`

## Notes
- the updated skill submodule points to branch `docs/extra-field-api` in `coekfung/zotero-plugin-template-skill`