### PR TITLE
feat: improve venue alias feedback

### DIFF
--- a/addon/locale/en-US/addon.ftl
+++ b/addon/locale/en-US/addon.ftl
@@ -22,3 +22,28 @@ venue-alias-updated =
         [one] Updated { $count } venue alias
        *[other] Updated { $count } venue aliases
     }
+venue-alias-summary-updated =
+    { $count ->
+        [one] { $count } updated
+       *[other] { $count } updated
+    }
+venue-alias-summary-uptodate =
+    { $count ->
+        [one] { $count } already up to date
+       *[other] { $count } already up to date
+    }
+venue-alias-summary-missing-doi =
+    { $count ->
+        [one] { $count } missing DOI
+       *[other] { $count } missing DOI
+    }
+venue-alias-summary-not-found =
+    { $count ->
+        [one] { $count } not found
+       *[other] { $count } not found
+    }
+venue-alias-summary-failed =
+    { $count ->
+        [one] { $count } failed
+       *[other] { $count } failed
+    }

--- a/addon/locale/zh-CN/addon.ftl
+++ b/addon/locale/zh-CN/addon.ftl
@@ -22,3 +22,28 @@ venue-alias-updated =
         [one] 已更新 { $count } 个期刊/会议别名
        *[other] 已更新 { $count } 个期刊/会议别名
     }
+venue-alias-summary-updated =
+    { $count ->
+        [one] { $count } 个已更新
+       *[other] { $count } 个已更新
+    }
+venue-alias-summary-uptodate =
+    { $count ->
+        [one] { $count } 个已是最新
+       *[other] { $count } 个已是最新
+    }
+venue-alias-summary-missing-doi =
+    { $count ->
+        [one] { $count } 个缺少 DOI
+       *[other] { $count } 个缺少 DOI
+    }
+venue-alias-summary-not-found =
+    { $count ->
+        [one] { $count } 个未找到
+       *[other] { $count } 个未找到
+    }
+venue-alias-summary-failed =
+    { $count ->
+        [one] { $count } 个请求失败
+       *[other] { $count } 个请求失败
+    }

--- a/src/modules/venueAlias.ts
+++ b/src/modules/venueAlias.ts
@@ -5,6 +5,37 @@ const CROSSREF_API_URL = "https://api.crossref.org/works/";
 const VENUE_ALIAS_KEY = "Venue Alias";
 const extraFieldTool = new ExtraFieldTool();
 
+export enum VenueAliasResult {
+  MissingDOI = "missingDOI",
+  NotFound = "notFound",
+  AlreadyUpToDate = "alreadyUpToDate",
+  Updated = "updated",
+  RequestFailed = "requestFailed",
+}
+
+function getErrorStatus(error: unknown): number | undefined {
+  if (!error || typeof error !== "object") {
+    return undefined;
+  }
+
+  const status = "status" in error ? error.status : undefined;
+  if (typeof status === "number") {
+    return status;
+  }
+
+  const xmlhttp = "xmlhttp" in error ? error.xmlhttp : undefined;
+  if (
+    xmlhttp &&
+    typeof xmlhttp === "object" &&
+    "status" in xmlhttp &&
+    typeof xmlhttp.status === "number"
+  ) {
+    return xmlhttp.status;
+  }
+
+  return undefined;
+}
+
 interface CrossrefWorkMessage {
   "short-container-title"?: unknown;
 }
@@ -46,31 +77,42 @@ export function normalizeVenueAlias(alias: string): string | undefined {
   return normalizedAlias || undefined;
 }
 
-async function updateVenueAliasForItem(item: Zotero.Item): Promise<boolean> {
+async function updateVenueAliasForItem(
+  item: Zotero.Item,
+): Promise<VenueAliasResult> {
   const doi = item.getField("DOI").trim();
   if (!doi) {
-    return false;
+    return VenueAliasResult.MissingDOI;
   }
 
-  const nextAlias = await fetchCrossrefVenueAlias(doi);
+  let nextAlias: string | undefined;
+  try {
+    nextAlias = await fetchCrossrefVenueAlias(doi);
+  } catch (error) {
+    if (getErrorStatus(error) === 404) {
+      return VenueAliasResult.NotFound;
+    }
+    throw error;
+  }
+
   if (!nextAlias) {
-    return false;
+    return VenueAliasResult.NotFound;
   }
 
   const normalizedAlias = normalizeVenueAlias(nextAlias);
   if (!normalizedAlias) {
-    return false;
+    return VenueAliasResult.NotFound;
   }
 
   const currentAlias = extraFieldTool.getExtraField(item, VENUE_ALIAS_KEY);
   if (currentAlias === normalizedAlias) {
-    return false;
+    return VenueAliasResult.AlreadyUpToDate;
   }
 
   await extraFieldTool.setExtraField(item, VENUE_ALIAS_KEY, normalizedAlias, {
     append: false,
   });
-  return true;
+  return VenueAliasResult.Updated;
 }
 
 function getSelectedRegularItems(): Zotero.Item[] {
@@ -87,6 +129,98 @@ function showResultWindow(text: string, type: "default" | "success" | "fail") {
   })
     .createLine({ text, type })
     .show();
+}
+
+export interface VenueAliasCounts {
+  [VenueAliasResult.MissingDOI]: number;
+  [VenueAliasResult.NotFound]: number;
+  [VenueAliasResult.AlreadyUpToDate]: number;
+  [VenueAliasResult.Updated]: number;
+  [VenueAliasResult.RequestFailed]: number;
+}
+
+export function getSummaryEntries(
+  counts: VenueAliasCounts,
+): Array<[VenueAliasResult, number]> {
+  const entries: Array<[VenueAliasResult, number]> = [];
+
+  if (counts[VenueAliasResult.Updated] > 0) {
+    entries.push([VenueAliasResult.Updated, counts[VenueAliasResult.Updated]]);
+  }
+
+  if (counts[VenueAliasResult.AlreadyUpToDate] > 0) {
+    entries.push([
+      VenueAliasResult.AlreadyUpToDate,
+      counts[VenueAliasResult.AlreadyUpToDate],
+    ]);
+  }
+
+  if (counts[VenueAliasResult.MissingDOI] > 0) {
+    entries.push([
+      VenueAliasResult.MissingDOI,
+      counts[VenueAliasResult.MissingDOI],
+    ]);
+  }
+
+  if (counts[VenueAliasResult.NotFound] > 0) {
+    entries.push([
+      VenueAliasResult.NotFound,
+      counts[VenueAliasResult.NotFound],
+    ]);
+  }
+
+  if (counts[VenueAliasResult.RequestFailed] > 0) {
+    entries.push([
+      VenueAliasResult.RequestFailed,
+      counts[VenueAliasResult.RequestFailed],
+    ]);
+  }
+
+  return entries;
+}
+
+export function createEmptyVenueAliasCounts(): VenueAliasCounts {
+  return {
+    [VenueAliasResult.MissingDOI]: 0,
+    [VenueAliasResult.NotFound]: 0,
+    [VenueAliasResult.AlreadyUpToDate]: 0,
+    [VenueAliasResult.Updated]: 0,
+    [VenueAliasResult.RequestFailed]: 0,
+  };
+}
+
+export function buildSummaryString(
+  counts: VenueAliasCounts,
+  total: number,
+): string {
+  const parts = getSummaryEntries(counts).map(([result, count]) => {
+    switch (result) {
+      case VenueAliasResult.Updated:
+        return getString("venue-alias-summary-updated", { args: { count } });
+      case VenueAliasResult.AlreadyUpToDate:
+        return getString("venue-alias-summary-uptodate", { args: { count } });
+      case VenueAliasResult.MissingDOI:
+        return getString("venue-alias-summary-missing-doi", {
+          args: { count },
+        });
+      case VenueAliasResult.NotFound:
+        return getString("venue-alias-summary-not-found", { args: { count } });
+      case VenueAliasResult.RequestFailed:
+        return getString("venue-alias-summary-failed", { args: { count } });
+    }
+  });
+
+  if (parts.length === 0) {
+    return getString("venue-alias-no-update");
+  }
+
+  // For single item, show concise outcome
+  if (total === 1) {
+    return parts[0]!;
+  }
+
+  // For multiple items, join with comma
+  return parts.join(", ");
 }
 
 export class VenueAliasFactory {
@@ -112,26 +246,25 @@ export class VenueAliasFactory {
       return;
     }
 
-    let updated = 0;
+    const counts = createEmptyVenueAliasCounts();
 
     for (const item of items) {
       try {
-        if (await updateVenueAliasForItem(item)) {
-          updated += 1;
-        }
+        const result = await updateVenueAliasForItem(item);
+        counts[result]++;
       } catch (error) {
+        counts[VenueAliasResult.RequestFailed]++;
         ztoolkit.log("Failed to fetch venue alias", item.id, error);
       }
     }
 
-    if (updated > 0) {
-      showResultWindow(
-        getString("venue-alias-updated", { args: { count: updated } }),
-        "success",
-      );
-      return;
-    }
-
-    showResultWindow(getString("venue-alias-no-update"), "default");
+    const summary = buildSummaryString(counts, items.length);
+    const type =
+      counts[VenueAliasResult.Updated] > 0
+        ? "success"
+        : counts[VenueAliasResult.RequestFailed] > 0
+          ? "fail"
+          : "default";
+    showResultWindow(summary, type);
   }
 }

--- a/test/venueAlias.test.ts
+++ b/test/venueAlias.test.ts
@@ -2,8 +2,11 @@
 
 import { assert } from "chai";
 import {
+  createEmptyVenueAliasCounts,
   extractVenueAliasFromCrossref,
+  getSummaryEntries,
   normalizeVenueAlias,
+  VenueAliasResult,
 } from "../src/modules/venueAlias";
 
 describe("venue alias", function () {
@@ -34,5 +37,35 @@ describe("venue alias", function () {
 
   it("returns undefined for blank normalized aliases", function () {
     assert.isUndefined(normalizeVenueAlias("  \n  "));
+  });
+
+  it("has VenueAliasResult enum values", function () {
+    assert.equal(VenueAliasResult.MissingDOI, "missingDOI");
+    assert.equal(VenueAliasResult.NotFound, "notFound");
+    assert.equal(VenueAliasResult.AlreadyUpToDate, "alreadyUpToDate");
+    assert.equal(VenueAliasResult.Updated, "updated");
+    assert.equal(VenueAliasResult.RequestFailed, "requestFailed");
+  });
+
+  it("builds summary entries for a single-item outcome", function () {
+    const counts = createEmptyVenueAliasCounts();
+    counts[VenueAliasResult.MissingDOI] = 1;
+
+    assert.deepEqual(getSummaryEntries(counts), [
+      [VenueAliasResult.MissingDOI, 1],
+    ]);
+  });
+
+  it("builds summary entries in stable order", function () {
+    const counts = createEmptyVenueAliasCounts();
+    counts[VenueAliasResult.Updated] = 2;
+    counts[VenueAliasResult.AlreadyUpToDate] = 1;
+    counts[VenueAliasResult.NotFound] = 3;
+
+    assert.deepEqual(getSummaryEntries(counts), [
+      [VenueAliasResult.Updated, 2],
+      [VenueAliasResult.AlreadyUpToDate, 1],
+      [VenueAliasResult.NotFound, 3],
+    ]);
   });
 });

--- a/typings/i10n.d.ts
+++ b/typings/i10n.d.ts
@@ -27,4 +27,9 @@ export type FluentMessageId =
   | 'venue-alias-menuitem'
   | 'venue-alias-no-items'
   | 'venue-alias-no-update'
+  | 'venue-alias-summary-failed'
+  | 'venue-alias-summary-missing-doi'
+  | 'venue-alias-summary-not-found'
+  | 'venue-alias-summary-updated'
+  | 'venue-alias-summary-uptodate'
   | 'venue-alias-updated';


### PR DESCRIPTION
## Summary
- improve manual venue-alias fetch feedback by distinguishing updated, already up to date, missing DOI, not found, and request failed outcomes
- classify Crossref 404 responses as not found instead of generic request failures
- add localized summary strings and focused tests for the new summary ordering/count helpers

## Plan
### Current PR
- keep the existing manual Crossref venue-alias workflow
- make result feedback more informative for single-item and multi-item runs
- preserve the current storage model and avoid expanding data scope

## Deferred
### Later PRs
1. Optional source expansion
   - keep Crossref primary
   - add Semantic Scholar only as a fallback if Crossref proves insufficient for CS/AI conference aliases
2. Optional batch workflow
   - add selected-items refresh/fill-missing flows if the manual action proves useful
3. Optional copy polish
   - refine single-item wording beyond count-based summaries if needed after real use

## Out of scope
- namespace for `Venue Alias`
- canonical venue field
- source/timestamp/version metadata in `extra`
- background auto-fetch on import or selection
- generic enrichment framework

## Validation
- `npm run build`
- `npm run lint:check`
- `npm test -- --exit-on-finish`