### PR TITLE
feat: add venue alias item list column

### DIFF
--- a/addon/locale/en-US/addon.ftl
+++ b/addon/locale/en-US/addon.ftl
@@ -15,6 +15,7 @@ tabpanel-lib-tab-label = Lib Tab
 tabpanel-reader-tab-label = Reader Tab
 venue-alias-menuitem =
     .label = Zotero Extra: Fetch Venue Alias
+venue-alias-column-label = Venue Alias
 venue-alias-no-items = No items selected
 venue-alias-no-update = No venue aliases were updated
 venue-alias-updated =

--- a/addon/locale/zh-CN/addon.ftl
+++ b/addon/locale/zh-CN/addon.ftl
@@ -15,6 +15,7 @@ tabpanel-lib-tab-label = 库标签
 tabpanel-reader-tab-label = 阅读器标签
 venue-alias-menuitem =
     .label = Zotero Extra: 获取期刊/会议别名
+venue-alias-column-label = 期刊/会议别名
 venue-alias-no-items = 未选择条目
 venue-alias-no-update = 没有更新任何期刊/会议别名
 venue-alias-updated =

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -33,6 +33,8 @@ async function onStartup() {
 
   UIExampleFactory.registerWindowMenuWithSeparator();
 
+  await VenueAliasFactory.registerColumn();
+
   await UIExampleFactory.registerExtraColumn();
 
   await UIExampleFactory.registerExtraColumnWithCustomCell();
@@ -105,6 +107,7 @@ async function onMainWindowUnload(win: Window): Promise<void> {
 }
 
 function onShutdown(): void {
+  VenueAliasFactory.unregisterColumn();
   ztoolkit.unregisterAll();
   addon.data.dialog?.window?.close();
   // Remove addon object

--- a/src/modules/venueAlias.ts
+++ b/src/modules/venueAlias.ts
@@ -3,6 +3,7 @@ import { ExtraFieldTool } from "zotero-plugin-toolkit";
 
 const CROSSREF_API_URL = "https://api.crossref.org/works/";
 const VENUE_ALIAS_KEY = "Venue Alias";
+const VENUE_ALIAS_COLUMN_KEY = "venueAlias";
 const extraFieldTool = new ExtraFieldTool();
 
 export enum VenueAliasResult {
@@ -77,6 +78,11 @@ export function normalizeVenueAlias(alias: string): string | undefined {
   return normalizedAlias || undefined;
 }
 
+export function getVenueAlias(item: Zotero.Item): string | undefined {
+  const alias = extraFieldTool.getExtraField(item, VENUE_ALIAS_KEY);
+  return alias ? normalizeVenueAlias(alias) : undefined;
+}
+
 async function updateVenueAliasForItem(
   item: Zotero.Item,
 ): Promise<VenueAliasResult> {
@@ -104,7 +110,7 @@ async function updateVenueAliasForItem(
     return VenueAliasResult.NotFound;
   }
 
-  const currentAlias = extraFieldTool.getExtraField(item, VENUE_ALIAS_KEY);
+  const currentAlias = getVenueAlias(item);
   if (currentAlias === normalizedAlias) {
     return VenueAliasResult.AlreadyUpToDate;
   }
@@ -224,6 +230,19 @@ export function buildSummaryString(
 }
 
 export class VenueAliasFactory {
+  static async registerColumn() {
+    await Zotero.ItemTreeManager.registerColumns({
+      pluginID: addon.data.config.addonID,
+      dataKey: VENUE_ALIAS_COLUMN_KEY,
+      label: getString("venue-alias-column-label"),
+      dataProvider: (item: Zotero.Item) => getVenueAlias(item) ?? "",
+    });
+  }
+
+  static unregisterColumn() {
+    Zotero.ItemTreeManager.unregisterColumns(addon.data.config.addonID);
+  }
+
   static registerItemMenu() {
     Zotero.MenuManager.registerMenu({
       pluginID: addon.data.config.addonID,

--- a/typings/i10n.d.ts
+++ b/typings/i10n.d.ts
@@ -24,6 +24,7 @@ export type FluentMessageId =
   | 'startup-finish'
   | 'tabpanel-lib-tab-label'
   | 'tabpanel-reader-tab-label'
+  | 'venue-alias-column-label'
   | 'venue-alias-menuitem'
   | 'venue-alias-no-items'
   | 'venue-alias-no-update'


### PR DESCRIPTION
## Summary
- add a display-only Venue Alias column to the Zotero item list
- read column values from the existing `extra` field venue alias helper
- localize the column label and unregister the column on shutdown